### PR TITLE
Prep forrel update

### DIFF
--- a/R/DeT.R
+++ b/R/DeT.R
@@ -9,7 +9,7 @@
 #' library(forrel)
 #' x = linearPed(2)
 #' x = setMarkers(x, locusAttributes = NorwegianFrequencies[1:5])
-#' x = profileSim(x, N = 1, ids = 2)[[1]]
+#' x = profileSim(x, N = 1, ids = 2)
 #' datasim = simLRgen(x, missing = 5, 10, 123)
 #' DeT(datasim, 10)
 

--- a/R/LRdist.R
+++ b/R/LRdist.R
@@ -10,7 +10,7 @@
 #' library(forrel)
 #' x = linearPed(2)
 #' x = setMarkers(x, locusAttributes = NorwegianFrequencies[1:5])
-#' x = profileSim(x, N = 1, ids = 2)[[1]]
+#' x = profileSim(x, N = 1, ids = 2)
 #' datasim = simLRgen(x, missing = 5, 10, 123)
 #' LRdist(datasim)
 #' @import plotly

--- a/R/Trates.R
+++ b/R/Trates.R
@@ -10,7 +10,7 @@
 #' library(forrel)
 #' x = linearPed(2)
 #' x = setMarkers(x, locusAttributes = NorwegianFrequencies[1:5])
-#' x = profileSim(x, N = 1, ids = 2)[[1]]
+#' x = profileSim(x, N = 1, ids = 2)
 #' datasim = simLRgen(x, missing = 5, 10, 123)
 #' Trates(datasim, 10)
 

--- a/R/combLR.R
+++ b/R/combLR.R
@@ -10,7 +10,7 @@
 #' library(forrel) 
 #' x = linearPed(2)
 #' x = setMarkers(x, locusAttributes = NorwegianFrequencies[1:5])
-#' x = profileSim(x, N = 1, ids = 2)[[1]]
+#' x = profileSim(x, N = 1, ids = 2)
 #' LRdatasim1 = simLRgen(x, missing = 5, 10, 123)
 #' LRdatasim2 = simLRprelim("sex")
 #' combLR(LRdatasim1,LRdatasim2)

--- a/R/deplot.R
+++ b/R/deplot.R
@@ -10,7 +10,7 @@
 #' library(plotly)
 #' x = linearPed(2)
 #' x = setMarkers(x, locusAttributes = NorwegianFrequencies[1:5])
-#' x = profileSim(x, N = 1, ids = 2)[[1]]
+#' x = profileSim(x, N = 1, ids = 2)
 #' datasim = simLRgen(x, missing = 5, 10, 123)
 #' deplot(datasim)
 #' @import plotly

--- a/R/simLRgen.R
+++ b/R/simLRgen.R
@@ -11,11 +11,11 @@
 #' @import pedtools
 #'
 #' @examples
-#' library(forrel) 
+#' library(forrel)
 #' x = linearPed(2)
+#' plot(x)
 #' x = setMarkers(x, locusAttributes = NorwegianFrequencies[1:5])
 #' x = profileSim(x, N = 1, ids = 2)
-#' plot(x)
 #' datasim = simLRgen(x, missing = 5, 10, 123)
 
 
@@ -23,6 +23,9 @@
 
 simLRgen = function(reference, missing, numsims, seed) {
   st = base::Sys.time()
+
+  if(pedtools::is.pedList(reference) && base::length(reference) == 1)
+    reference = reference[[1]]
 
   if(!pedtools::is.ped(reference))
     base::stop("Expecting a connected pedigree as H1")

--- a/R/simLRgen.R
+++ b/R/simLRgen.R
@@ -14,7 +14,7 @@
 #' library(forrel) 
 #' x = linearPed(2)
 #' x = setMarkers(x, locusAttributes = NorwegianFrequencies[1:5])
-#' x = profileSim(x, N = 1, ids = 2)[[1]]
+#' x = profileSim(x, N = 1, ids = 2)
 #' plot(x)
 #' datasim = simLRgen(x, missing = 5, 10, 123)
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ library(mispitools)
 library(forrel)
 x = linearPed(2)
 x = setMarkers(x, locusAttributes = NorwegianFrequencies[1:5])
-x = profileSim(x, N = 1, ids = 2)[[1]]
+x = profileSim(x, N = 1, ids = 2)
 datasim = makeLRsims(x, missing = 5, 1000, 123)
 ```
 

--- a/man/DeT.Rd
+++ b/man/DeT.Rd
@@ -21,7 +21,7 @@ Decision Threshold: a function for computing likelihood ratio decision threshold
 library(forrel)
 x = linearPed(2)
 x = setMarkers(x, locusAttributes = NorwegianFrequencies[1:5])
-x = profileSim(x, N = 1, ids = 2)[[1]]
+x = profileSim(x, N = 1, ids = 2)
 datasim = simLRgen(x, missing = 5, 10, 123)
 DeT(datasim, 10)
 }

--- a/man/LRdist.Rd
+++ b/man/LRdist.Rd
@@ -21,7 +21,7 @@ Likelihood ratio distribution: a function for plotting expected log10(LR) distri
 library(forrel)
 x = linearPed(2)
 x = setMarkers(x, locusAttributes = NorwegianFrequencies[1:5])
-x = profileSim(x, N = 1, ids = 2)[[1]]
+x = profileSim(x, N = 1, ids = 2)
 datasim = simLRgen(x, missing = 5, 10, 123)
 LRdist(datasim)
 }

--- a/man/Trates.Rd
+++ b/man/Trates.Rd
@@ -21,7 +21,7 @@ Threshold rates: a function for computing error rates and Matthews correlation c
 library(forrel)
 x = linearPed(2)
 x = setMarkers(x, locusAttributes = NorwegianFrequencies[1:5])
-x = profileSim(x, N = 1, ids = 2)[[1]]
+x = profileSim(x, N = 1, ids = 2)
 datasim = simLRgen(x, missing = 5, 10, 123)
 Trates(datasim, 10)
 }

--- a/man/combLR.Rd
+++ b/man/combLR.Rd
@@ -22,7 +22,7 @@ library(mispitools)
 library(forrel) 
 x = linearPed(2)
 x = setMarkers(x, locusAttributes = NorwegianFrequencies[1:5])
-x = profileSim(x, N = 1, ids = 2)[[1]]
+x = profileSim(x, N = 1, ids = 2)
 LRdatasim1 = simLRgen(x, missing = 5, 10, 123)
 LRdatasim2 = simLRprelim("sex")
 combLR(LRdatasim1,LRdatasim2)

--- a/man/deplot.Rd
+++ b/man/deplot.Rd
@@ -20,7 +20,7 @@ library(forrel)
 library(plotly)
 x = linearPed(2)
 x = setMarkers(x, locusAttributes = NorwegianFrequencies[1:5])
-x = profileSim(x, N = 1, ids = 2)[[1]]
+x = profileSim(x, N = 1, ids = 2)
 datasim = simLRgen(x, missing = 5, 10, 123)
 deplot(datasim)
 }

--- a/man/simLRgen.Rd
+++ b/man/simLRgen.Rd
@@ -22,10 +22,10 @@ An object of class data.frame with LRs obtained for both hypothesis, Unrelated w
 Simulate likelihoods ratio (LRs) based on genetic data: a function for obtaining expected LRs under relatedness and unrelatedness kinship hypothesis.
 }
 \examples{
-library(forrel) 
+library(forrel)
 x = linearPed(2)
+plot(x)
 x = setMarkers(x, locusAttributes = NorwegianFrequencies[1:5])
 x = profileSim(x, N = 1, ids = 2)
-plot(x)
 datasim = simLRgen(x, missing = 5, 10, 123)
 }

--- a/man/simLRgen.Rd
+++ b/man/simLRgen.Rd
@@ -25,7 +25,7 @@ Simulate likelihoods ratio (LRs) based on genetic data: a function for obtaining
 library(forrel) 
 x = linearPed(2)
 x = setMarkers(x, locusAttributes = NorwegianFrequencies[1:5])
-x = profileSim(x, N = 1, ids = 2)[[1]]
+x = profileSim(x, N = 1, ids = 2)
 plot(x)
 datasim = simLRgen(x, missing = 5, 10, 123)
 }


### PR DESCRIPTION
The next version of `forrel` will include a breaking change of `profileSim()`, namely that `profileSim(..., N=1)` will output the ped object directly, not a list of length 1.

I've added a safeguard against this and modified some examples.
