### PR TITLE
Added context docstring for lrComparisonApp()

### DIFF
--- a/R/mispiAppv2.R
+++ b/R/mispiAppv2.R
@@ -1,5 +1,6 @@
 #' Missing person shiny app (versión mejorada)
-#'
+# Minor formatting update for documentation clarity
+
 #' @import shiny
 #' @import shinythemes
 #' @import ggplot2

--- a/R/mispiAppv2.R
+++ b/R/mispiAppv2.R
@@ -18,6 +18,10 @@ library(ggplot2)
 install.packages("reshape2")
 install.packages("pROC")  # para calcular AUC fácilmente
 
+#' @param None
+#' Context: Launches the interactive Shiny app for LR comparison and ROC visualization.
+#' Users can adjust missing-person parameters and explore calibration metrics.
+
 #' @import shiny
 #' @import shinythemes
 #' @import ggplot2


### PR DESCRIPTION
Added a short @param section to explain what the lrComparisonApp() function does and give context about how users interact with the Shiny app for better readability. This makes it clearer for anyone new to the repo what the app actually launches and why it’s useful. No functional changes were made as currently, it makes more sense to improve documentation readability