### PR TITLE
Correct biological axis labels in LR plots

### DIFF
--- a/R/CondPlot.R
+++ b/R/CondPlot.R
@@ -1,4 +1,4 @@
-#' General plot for condiionted probabilities and LR combining variables
+#' General plot for conditioned probabilities and LR combining variables
 #'
 #' @param CPT_POP Population conditioned probability table
 #' @param CPT_MP Missing person conditioned probability table
@@ -20,7 +20,7 @@ POP <- reshape2::melt(CPT_POP)
 p1 <- ggplot2::ggplot(POP, aes(x = Var2, y = Var1)) +
   ggplot2::geom_raster(aes(fill=value)) +
  scale_fill_gradient(low="grey90", high="blue") +
-  labs(x="Hair colour (C)", y="Biologocial sex-Age", title="P(D|H2)", limits = c(0,1)) +
+  labs(x="Hair colour (C)", y="Biological sex-Age", title="P(D|H2)", limits = c(0,1)) +
   theme_bw() + theme(axis.text.x=element_text(size=13, angle=0, vjust=0.3),
                      axis.text.y=element_text(size=13),
                      plot.title=element_text(size=13)) + 
@@ -31,7 +31,7 @@ MP <- reshape2::melt(CPT_MP)
 p2 <- ggplot2::ggplot(MP, aes(x = Var2, y = Var1)) +
   ggplot2::geom_raster(aes(fill=value)) +
   scale_fill_gradient(low="grey90", high="blue", limits = c(0,1)) +
-  labs(x="Hair colour (C)", y="Biologocial sex-Age", title="P(D|H1)") +
+  labs(x="Hair colour (C)", y="Biological sex-Age", title="P(D|H1)") +
   theme_bw() + theme(axis.text.x=element_text(size=13, angle=0, vjust=0.3),
                      axis.text.y=element_text(size=13),
                      plot.title=element_text(size=13)) + 
@@ -42,7 +42,7 @@ LR <- reshape2::melt(LRtable)
 p3 <- ggplot2::ggplot(LR, aes(x = Var2, y = Var1)) +
   ggplot2::geom_raster(aes(fill=value)) +
   scale_fill_gradient(low="grey90", high="blue") +
-  labs(x="Hair colour (C)", y="Biologocial sex-Age", title="Log10(LR)") +
+  labs(x="Hair colour (C)", y="Biological sex-Age", title="Log10(LR)") +
   theme_bw() + theme(axis.text.x=element_text(size=13, angle=0, vjust=0.3),
                      axis.text.y=element_text(size=13),
                      plot.title=element_text(size=13)) + 

--- a/R/mispiApp.R
+++ b/R/mispiApp.R
@@ -98,7 +98,7 @@ server <- function(input, output) {
     p1 <- ggplot2::ggplot(POP, aes(x = Var2, y = Var1)) +
       ggplot2::geom_raster(aes(fill=value)) +
       scale_fill_gradient(low="grey90", high="blue", limits = c(0,1)) +
-      labs(x="Hair colour (C)", y="Biologocial sex-Age", title="P(D|H2)", limits = c(0,1)) +
+      labs(x="Hair colour (C)", y="Biological sex-Age", title="P(D|H2)", limits = c(0,1)) +
       theme_bw() + theme(axis.text.x=element_text(size=13, angle=0, vjust=0.3),
                          axis.text.y=element_text(size=13),
                          plot.title=element_text(size=13)) +
@@ -107,7 +107,7 @@ server <- function(input, output) {
     p2 <- ggplot2::ggplot(MP, aes(x = Var2, y = Var1)) +
       ggplot2::geom_raster(aes(fill=value)) +
       scale_fill_gradient(low="grey90", high="blue", limits = c(0,1)) +
-      labs(x="Hair colour (C)", y="Biologocial sex-Age", title="P(D|H1)") +
+      labs(x="Hair colour (C)", y="Biological sex-Age", title="P(D|H1)") +
       theme_bw() + theme(axis.text.x=element_text(size=13, angle=0, vjust=0.3),
                          axis.text.y=element_text(size=13),
                          plot.title=element_text(size=13)) +
@@ -117,7 +117,7 @@ server <- function(input, output) {
     p3 <- ggplot2::ggplot(LR, aes(x = Var2, y = Var1)) +
       ggplot2::geom_raster(aes(fill=value)) +
       scale_fill_gradient(low="grey90", high="blue") +
-      labs(x="Hair colour (C)", y="Biologocial sex-Age", title="Log10(LR)") +
+      labs(x="Hair colour (C)", y="Biological sex-Age", title="Log10(LR)") +
       theme_bw() + theme(axis.text.x=element_text(size=13, angle=0, vjust=0.3),
                          axis.text.y=element_text(size=13),
                          plot.title=element_text(size=13)) +


### PR DESCRIPTION
## Summary
- correct the spelling of biological sex-age axis labels in CondPlot and the Shiny app visualizations
- fix the roxygen title typo for the conditioned probability plot helper

## Testing
- not run (Rscript not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695316abb2988332aaaa92ef429d0ab6)